### PR TITLE
Extend SAID crate

### DIFF
--- a/.github/workflows/publish-said.yml
+++ b/.github/workflows/publish-said.yml
@@ -32,3 +32,4 @@ jobs:
         with:
             path: './said'
             registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+            args: '--all-features'

--- a/cesr/Cargo.toml
+++ b/cesr/Cargo.toml
@@ -24,4 +24,4 @@ anyhow = "1"
 
 [dev-dependencies]
 hex = "0.4.3"
-ed25519-dalek = "1.0.1"
+ed25519-dalek = "2.2.0"

--- a/cesr/Cargo.toml
+++ b/cesr/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["keri", "dkms", "cesr"]
 cesr-proof = []
 
 [dependencies]
-base64 = "0.13"
+base64 = "0.22"
 nom = "7"
 chrono = "0.4"
 serde = { version = "1.0", features = ["derive"] }

--- a/cesr/Cargo.toml
+++ b/cesr/Cargo.toml
@@ -16,7 +16,7 @@ base64 = "0.22"
 nom = "7"
 chrono = "0.4"
 serde = { version = "1.0", features = ["derive"] }
-thiserror = "1.0"
+thiserror = "2.0"
 serde_json = "1.0"
 serde_cbor = "0.11.1"
 rmp-serde = "1.1.1"

--- a/cesr/src/cesr_proof/mod.rs
+++ b/cesr/src/cesr_proof/mod.rs
@@ -1,4 +1,4 @@
-use base64::URL_SAFE;
+use base64::prelude::*;
 use serde::Deserialize;
 
 use crate::{
@@ -50,7 +50,7 @@ impl MaterialPath {
     }
 
     pub fn to_cesr(&self) -> String {
-        let decoded_base = base64::decode_config(&self.base, URL_SAFE).unwrap();
+        let decoded_base = BASE64_URL_SAFE.decode(&self.base).unwrap();
 
         let size = decoded_base.len() / 3;
         let code = VariableLengthCode::Small {
@@ -62,7 +62,7 @@ impl MaterialPath {
     }
 
     pub fn to_raw(&self) -> Result<Vec<u8>, Error> {
-        let decoded_base = base64::decode_config(&self.base, URL_SAFE)?;
+        let decoded_base = BASE64_URL_SAFE.decode(&self.base).unwrap();
         let raw = &decoded_base[self.lead_bytes..];
         Ok(raw.to_vec())
     }

--- a/cesr/src/conversion.rs
+++ b/cesr/src/conversion.rs
@@ -1,4 +1,4 @@
-use base64::{encode_config, URL_SAFE};
+use base64::prelude::*;
 
 use super::error::Error;
 
@@ -6,7 +6,7 @@ pub fn from_text_to_bytes(text: &str) -> Result<Vec<u8>, Error> {
     let lead_size = (4 - (text.len() % 4)) % 4;
     let full_derivative = [&"A".repeat(lead_size), text].concat();
 
-    Ok(base64::decode_config(full_derivative, URL_SAFE)?.to_vec())
+    Ok(BASE64_URL_SAFE.decode(full_derivative)?.to_vec())
 }
 
 pub fn from_bytes_to_text(bytes: &[u8]) -> String {
@@ -15,7 +15,7 @@ pub fn from_bytes_to_text(bytes: &[u8]) -> String {
         .chain(bytes.iter().copied())
         .collect();
 
-    encode_config(full_derivative, base64::URL_SAFE)
+    BASE64_URL_SAFE.encode(full_derivative)
 }
 
 /// Parses the number from radix 64 using digits from url-safe base64 (`A` = 0, `_` = 63)

--- a/cesr/src/primitives/codes/self_addressing.rs
+++ b/cesr/src/primitives/codes/self_addressing.rs
@@ -5,8 +5,8 @@ use crate::{derivation_code::DerivationCode, error::Error};
 #[derive(Debug, PartialEq, Clone, Hash, Eq)]
 pub enum SelfAddressing {
     Blake3_256,
-    Blake2B256(Vec<u8>),
-    Blake2S256(Vec<u8>),
+    Blake2B256,
+    Blake2S256,
     SHA3_256,
     SHA2_256,
     Blake3_512,
@@ -19,8 +19,8 @@ impl DerivationCode for SelfAddressing {
     fn value_size(&self) -> usize {
         match self {
             Self::Blake3_256
-            | Self::Blake2B256(_)
-            | Self::Blake2S256(_)
+            | Self::Blake2B256
+            | Self::Blake2S256
             | Self::SHA3_256
             | Self::SHA2_256 => 43,
             Self::Blake3_512 | Self::SHA3_512 | Self::Blake2B512 | Self::SHA2_512 => 86,
@@ -34,8 +34,8 @@ impl DerivationCode for SelfAddressing {
     fn hard_size(&self) -> usize {
         match self {
             Self::Blake3_256
-            | Self::Blake2B256(_)
-            | Self::Blake2S256(_)
+            | Self::Blake2B256
+            | Self::Blake2S256
             | Self::SHA3_256
             | Self::SHA2_256 => 1,
             Self::Blake3_512 | Self::SHA3_512 | Self::Blake2B512 | Self::SHA2_512 => 2,
@@ -45,8 +45,8 @@ impl DerivationCode for SelfAddressing {
     fn to_str(&self) -> String {
         match self {
             Self::Blake3_256 => "E",
-            Self::Blake2B256(_) => "F",
-            Self::Blake2S256(_) => "G",
+            Self::Blake2B256 => "F",
+            Self::Blake2S256 => "G",
             Self::SHA3_256 => "H",
             Self::SHA2_256 => "I",
             Self::Blake3_512 => "0D",
@@ -64,8 +64,8 @@ impl FromStr for SelfAddressing {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.get(..1).ok_or(Error::EmptyCodeError)? {
             "E" => Ok(Self::Blake3_256),
-            "F" => Ok(Self::Blake2B256(vec![])),
-            "G" => Ok(Self::Blake2S256(vec![])),
+            "F" => Ok(Self::Blake2B256),
+            "G" => Ok(Self::Blake2S256),
             "H" => Ok(Self::SHA3_256),
             "I" => Ok(Self::SHA2_256),
             "0" => match &s[1..2] {

--- a/cesr/src/primitives/parsers.rs
+++ b/cesr/src/primitives/parsers.rs
@@ -89,6 +89,8 @@ pub fn anchoring_event_seal(s: &str) -> nom::IResult<&str, AnchoringEventSeal> {
 #[cfg(test)]
 pub mod tests {
 
+    use base64::prelude::*;
+
     use crate::{
         parse_one,
         primitives::{
@@ -114,7 +116,7 @@ pub mod tests {
         Ok(("AA", (AttachedSignatureCode::new_from_ints(SelfSigning::Ed25519Sha512, 2, None), vec![0u8; 64])))
     );
 
-        let expected_sig = base64::decode_config("mdI8OSQkMJ9r-xigjEByEjIua7LHH3AOJ22PQKqljMhuhcgh9nGRcKnsz5KvKd7K_H9-1298F4Id1DxvIoEmCQ==", base64::URL_SAFE).unwrap();
+        let expected_sig = BASE64_URL_SAFE.decode("mdI8OSQkMJ9r-xigjEByEjIua7LHH3AOJ22PQKqljMhuhcgh9nGRcKnsz5KvKd7K_H9-1298F4Id1DxvIoEmCQ==").unwrap();
         assert_eq!(
         parse_primitive::<AttachedSignatureCode>("AACZ0jw5JCQwn2v7GKCMQHISMi5rsscfcA4nbY9AqqWMyG6FyCH2cZFwqezPkq8p3sr8f37Xb3wXgh3UPG8igSYJ"),
         Ok(("", (AttachedSignatureCode::new_from_ints(SelfSigning::Ed25519Sha512, 0, Some(0)), expected_sig)))

--- a/cesr/tests/client.rs
+++ b/cesr/tests/client.rs
@@ -7,6 +7,7 @@ pub mod test {
         primitives::codes::{basic::Basic, self_signing::SelfSigning},
         value::Value,
     };
+    use base64::prelude::*;
 
     #[test]
     pub fn test_hello_cesr() {
@@ -29,19 +30,19 @@ pub mod test {
 
         assert_eq!(key_code, Basic::Ed25519Nontrans);
         assert_eq!(
-            base64::encode(pub_key),
-            "8pqFxDnqqRxpM2IaM1hQJDJ8ze740TKbM+/q0oVi2HE="
+            BASE64_URL_SAFE.encode(pub_key),
+            "8pqFxDnqqRxpM2IaM1hQJDJ8ze740TKbM-_q0oVi2HE="
         );
 
         assert_eq!(sig_code, SelfSigning::Ed25519Sha512);
-        assert_eq!(base64::encode(signature), "vbirpUkmek2t9K3hAOJCJkAbvsGeISEl6EkjhigdJQSKZC2gTI1UtegPyjLMQbROlWy9UcvRRyQIO8oHWW6pCg==");
+        assert_eq!(BASE64_URL_SAFE.encode(signature), "vbirpUkmek2t9K3hAOJCJkAbvsGeISEl6EkjhigdJQSKZC2gTI1UtegPyjLMQbROlWy9UcvRRyQIO8oHWW6pCg==");
     }
 
     #[test]
     pub fn test_cesr_serialization_deserialization() -> Result<(), cesrox::error::Error> {
         use ed25519_dalek::{Keypair, PublicKey, SecretKey, Signature, Signer};
 
-        let seed = base64::decode("nWGxne/9WmC6hEr0kuwsxERJxWl7MmkZcDusAxyuf2A=").unwrap();
+        let seed = BASE64_URL_SAFE.decode("nWGxne_9WmC6hEr0kuwsxERJxWl7MmkZcDusAxyuf2A=").unwrap();
 
         let secret_key: SecretKey = SecretKey::from_bytes(&seed).unwrap();
         let public_key: PublicKey = (&secret_key).into();

--- a/cesr/tests/client.rs
+++ b/cesr/tests/client.rs
@@ -1,4 +1,5 @@
 pub mod test {
+    use base64::prelude::*;
     use cesrox::{
         error::{CESRError, ParsingError},
         group::Group,
@@ -7,7 +8,6 @@ pub mod test {
         primitives::codes::{basic::Basic, self_signing::SelfSigning},
         value::Value,
     };
-    use base64::prelude::*;
 
     #[test]
     pub fn test_hello_cesr() {
@@ -40,19 +40,13 @@ pub mod test {
 
     #[test]
     pub fn test_cesr_serialization_deserialization() -> Result<(), cesrox::error::Error> {
-        use ed25519_dalek::{
-            SigningKey,
-            VerifyingKey,
-            Signature,
-            Signer,
-            SECRET_KEY_LENGTH
-        };
+        use ed25519_dalek::{Signature, Signer, SigningKey, VerifyingKey, SECRET_KEY_LENGTH};
 
-        let seed_bytes = BASE64_STANDARD.decode("nWGxne/9WmC6hEr0kuwsxERJxWl7MmkZcDusAxyuf2A=").unwrap();
+        let seed_bytes = BASE64_STANDARD
+            .decode("nWGxne/9WmC6hEr0kuwsxERJxWl7MmkZcDusAxyuf2A=")
+            .unwrap();
 
-        let seed: [u8; SECRET_KEY_LENGTH] = seed_bytes
-            .try_into()
-            .expect("seed must be 32 bytes");
+        let seed: [u8; SECRET_KEY_LENGTH] = seed_bytes.try_into().expect("seed must be 32 bytes");
 
         let signing_key: SigningKey = SigningKey::from_bytes(&seed);
         let verifying_key: VerifyingKey = signing_key.verifying_key();
@@ -64,7 +58,7 @@ pub mod test {
         let signature = (SelfSigning::Ed25519Sha512, ed_signature.to_bytes().to_vec());
 
         let attachment =
-        Group::NontransReceiptCouples(vec![(public_key.clone(), signature.clone())]);
+            Group::NontransReceiptCouples(vec![(public_key.clone(), signature.clone())]);
 
         let payload = Payload::JSON(message.to_vec());
 

--- a/said/Cargo.toml
+++ b/said/Cargo.toml
@@ -17,8 +17,8 @@ sha2 = "0.10.9"
 sha3 = "0.10.8"
 base64 = "0.22"
 serde = { version = "1.0", features = ["derive"] }
-thiserror = "1.0"
-clap = "3.0.0-beta.4"
+thiserror = "2.0"
+clap = "4.5.52"
 
 # sad_macros = { path = "./sad_macros", optional = true }
 sad_macros = { version = "0.2.0", optional = true }
@@ -26,7 +26,7 @@ sad_macros = { version = "0.2.0", optional = true }
 serde_json = "1.0"
 serde_cbor = "0.11.2"
 serde_derive = "1.0.152"
-rmp-serde = "0.15"
-nom = "7"
+rmp-serde = "1.3"
+nom = "8"
 indexmap = {version = "2.3.0", features= ["serde"]}
 

--- a/said/Cargo.toml
+++ b/said/Cargo.toml
@@ -11,11 +11,11 @@ file = []
 
 [dependencies]
 cesrox = {path = "../cesr"}
-blake2 = "0.9.1"
+blake2 = "0.10.6"
 blake3 = { version = "1", default-features = false }
-sha2 = "0.9.3"
-sha3 = "0.9.1"
-base64 = "0.13"
+sha2 = "0.10.9"
+sha3 = "0.10.8"
+base64 = "0.22"
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
 clap = "3.0.0-beta.4"

--- a/said/Cargo.toml
+++ b/said/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "said"
-version = "0.4.2"
+version = "0.5.0"
 edition = "2021"
 description = "Self-Addressing identifier library"
 license = "EUPL-1.2"

--- a/said/README.md
+++ b/said/README.md
@@ -6,7 +6,7 @@ Self-Addressing Identifier (SAID) provides a compact text representation of dige
 
 ## License
 
-EUPL 1.2 
+EUPL 1.2
 
 We have distilled the most crucial license specifics to make your adoption seamless: [see here for details](https://github.com/THCLab/licensing).
 

--- a/said/src/bin/sai.rs
+++ b/said/src/bin/sai.rs
@@ -1,7 +1,7 @@
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 use cesrox::primitives::CesrPrimitive;
-use clap::{Command, Arg};
+use clap::{Arg, Command};
 use said::{derivation::HashFunction, SelfAddressingIdentifier};
 use std::{fs::File, io::BufReader, str::FromStr};
 

--- a/said/src/bin/sai.rs
+++ b/said/src/bin/sai.rs
@@ -1,21 +1,21 @@
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 use cesrox::primitives::CesrPrimitive;
-use clap::{App, Arg};
+use clap::{Command, Arg};
 use said::{derivation::HashFunction, SelfAddressingIdentifier};
 use std::{fs::File, io::BufReader, str::FromStr};
 
 fn main() {
-    let matches = App::new("SAI")
+    let matches = Command::new("SAI")
         .version(VERSION)
         .subcommand(
-            App::new("gen")
+            Command::new("gen")
                 .about("Generate Self-Addressing Identifier")
                 .arg(
                     Arg::new("data")
                         .short('d')
                         .long("data")
-                        .takes_value(true)
+                        .num_args(1)
                         .required_unless_present("file")
                         .help("Source data against which we would like to calculate digest"),
                 )
@@ -24,7 +24,7 @@ fn main() {
                         .short('f')
                         .long("file")
                         .required_unless_present("data")
-                        .takes_value(true)
+                        .num_args(1)
                         .help(
                             "File from which we would like to read data against which we would like to calculate digest"),
                 )
@@ -32,7 +32,7 @@ fn main() {
                     Arg::new("type")
                         .short('t')
                         .long("type")
-                        .takes_value(true)
+                        .num_args(1)
                         .required(true)
                         .help(
                             "Derevation code for the digest, algorithm used for digest.
@@ -50,13 +50,13 @@ Supported codes:
                 ),
         )
         .subcommand(
-            App::new("verify")
+            Command::new("verify")
                 .about("Verify SAI with provided data")
                 .arg(
                     Arg::new("sai")
                         .short('s')
                         .long("sai")
-                        .takes_value(true)
+                        .num_args(1)
                         .required(true)
                         .help("Digest against which we would like to verify the content"),
                 )
@@ -64,7 +64,7 @@ Supported codes:
                     Arg::new("data")
                         .short('d')
                         .long("data")
-                        .takes_value(true)
+                        .num_args(1)
                         .required(true)
                         .help("Source data against which we would like to verify given digest"),
                 ),
@@ -74,16 +74,17 @@ Supported codes:
     if let Some(matches) = matches.subcommand_matches("gen") {
         let mut data = Vec::new();
 
-        let code = matches.value_of("type").unwrap();
+        let code = matches.get_one::<String>("type").unwrap();
         let hash_algorithm = HashFunction::from_str(code).unwrap();
 
         if matches.contains_id("data") {
-            data.extend_from_slice(matches.value_of("data").unwrap().as_bytes());
+            data.extend_from_slice(matches.get_one::<String>("data").unwrap().as_bytes());
             let _calculated_sai = hash_algorithm.derive(&data).to_str();
+            println!("Calculated SAI: {}", _calculated_sai);
         }
 
         if matches.contains_id("file") {
-            let file_path = matches.value_of("file").unwrap();
+            let file_path = matches.get_one::<String>("file").unwrap();
             let file = File::open(file_path).expect("Unable to open file");
             let reader = BufReader::new(file);
 
@@ -95,8 +96,8 @@ Supported codes:
         }
     }
     if let Some(matches) = matches.subcommand_matches("verify") {
-        let _data = matches.value_of("data").unwrap().as_bytes();
-        let sai_str = matches.value_of("sai").unwrap();
+        let _data = matches.get_one::<String>("data").unwrap().as_bytes();
+        let sai_str = matches.get_one::<String>("sai").unwrap();
         let _sai: SelfAddressingIdentifier = sai_str
             .parse()
             .expect("Can't parse Self Addressing Identifier");

--- a/said/src/derivation/digest.rs
+++ b/said/src/derivation/digest.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "file")]
 use std::io::Read;
 
-use blake2::{Blake2b, Blake2b512, Digest, digest::consts::U32, Blake2s256};
+use blake2::{digest::consts::U32, Blake2b, Blake2b512, Blake2s256, Digest};
 use sha2::{Sha256, Sha512};
 use sha3::{Sha3_256, Sha3_512};
 
@@ -34,8 +34,6 @@ pub(crate) fn blake2s_256_digest(input: &[u8]) -> Vec<u8> {
     hasher.update(input);
     hasher.finalize().to_vec()
 }
-
-
 
 // TODO it seems that blake2b is always defined as outputting 512 bits?
 // TODO updated -> is this the one?

--- a/said/src/derivation/digest.rs
+++ b/said/src/derivation/digest.rs
@@ -1,9 +1,12 @@
 #[cfg(feature = "file")]
 use std::io::Read;
 
-use blake2::{Blake2b, Digest, VarBlake2b, VarBlake2s};
+use blake2::{Blake2b, Blake2b512, Digest, digest::consts::U32, Blake2s256};
 use sha2::{Sha256, Sha512};
 use sha3::{Sha3_256, Sha3_512};
+
+// This won't be needed in 0.11 of blake2
+type Blake2b256 = Blake2b<U32>;
 
 pub(crate) fn blake3_256_digest(input: &[u8]) -> Vec<u8> {
     blake3::hash(input).as_bytes().to_vec()
@@ -26,20 +29,20 @@ pub(crate) fn blake3_256_digest_stream<R: Read>(reader: &mut R) -> Result<Vec<u8
     Ok(hash.as_bytes()[..32].to_vec()) // Truncate to 256 bits if needed
 }
 
-pub(crate) fn blake2s_256_digest(input: &[u8], key: &[u8]) -> Vec<u8> {
-    use blake2::digest::{Update, VariableOutput};
-    let mut hasher = VarBlake2s::new_keyed(key, 256);
+pub(crate) fn blake2s_256_digest(input: &[u8]) -> Vec<u8> {
+    let mut hasher = Blake2s256::new();
     hasher.update(input);
-    hasher.finalize_boxed().to_vec()
+    hasher.finalize().to_vec()
 }
+
+
 
 // TODO it seems that blake2b is always defined as outputting 512 bits?
 // TODO updated -> is this the one?
-pub(crate) fn blake2b_256_digest(input: &[u8], key: &[u8]) -> Vec<u8> {
-    use blake2::digest::{Update, VariableOutput};
-    let mut hasher = VarBlake2b::new_keyed(key, 256);
+pub(crate) fn blake2b_256_digest(input: &[u8]) -> Vec<u8> {
+    let mut hasher = Blake2b256::new();
     hasher.update(input);
-    hasher.finalize_boxed().to_vec()
+    hasher.finalize().to_vec()
 }
 
 pub(crate) fn blake3_512_digest(input: &[u8]) -> Vec<u8> {
@@ -51,7 +54,7 @@ pub(crate) fn blake3_512_digest(input: &[u8]) -> Vec<u8> {
 }
 
 pub(crate) fn blake2b_512_digest(input: &[u8]) -> Vec<u8> {
-    let mut hasher = Blake2b::new();
+    let mut hasher = Blake2b512::new();
     hasher.update(input);
     hasher.finalize().to_vec()
 }

--- a/said/src/derivation/mod.rs
+++ b/said/src/derivation/mod.rs
@@ -28,8 +28,8 @@ impl HashFunction {
     pub fn digest(&self, data: &[u8]) -> Vec<u8> {
         match &self.0 {
             HashFunctionCode::Blake3_256 => digest::blake3_256_digest(data),
-            HashFunctionCode::Blake2B256(key) => digest::blake2b_256_digest(data, key),
-            HashFunctionCode::Blake2S256(key) => digest::blake2s_256_digest(data, key),
+            HashFunctionCode::Blake2B256 => digest::blake2b_256_digest(data),
+            HashFunctionCode::Blake2S256 => digest::blake2s_256_digest(data),
             HashFunctionCode::SHA3_256 => digest::sha3_256_digest(data),
             HashFunctionCode::SHA2_256 => digest::sha2_256_digest(data),
             HashFunctionCode::Blake3_512 => digest::blake3_512_digest(data),

--- a/said/src/lib.rs
+++ b/said/src/lib.rs
@@ -143,7 +143,7 @@ pub fn make_me_sad(
     version_str: ProtocolVersion,
     field_name: Option<&str>,
 ) -> Result<String, Error> {
-    let json: IndexMap<String, serde_json::Value> =
+    let mut json: IndexMap<String, serde_json::Value> =
         serde_json::from_str(input).map_err(|e| Error::DeserializeError(e.to_string()))?;
     // Use default version string with size 0
     let version = SerializationInfo::new(
@@ -153,6 +153,8 @@ pub fn make_me_sad(
         sad::SerializationFormats::JSON,
         0,
     );
+    // remove v field if the json structure already have it, it would be added with correctly calculated version later in this function
+    json.shift_remove("v");
     let mut versioned = Version {
         v: version,
         data: json,
@@ -190,7 +192,7 @@ pub fn make_me_sad(
 
 #[test]
 fn test_add_version() {
-    let input_str = r#"{"hi":"there","d":"","blah":"blah"}"#;
+    let input_str = r#"{"v":"","hi":"there","d":"","blah":"blah"}"#;
     let protocol_version = ProtocolVersion::new("DKMS", 0, 0).unwrap();
     let json_with_version =
         make_me_sad(&input_str, HashFunctionCode::Blake3_256, protocol_version, None).unwrap();

--- a/said/src/lib.rs
+++ b/said/src/lib.rs
@@ -194,8 +194,13 @@ pub fn make_me_sad(
 fn test_add_version() {
     let input_str = r#"{"v":"","hi":"there","d":"","blah":"blah"}"#;
     let protocol_version = ProtocolVersion::new("DKMS", 0, 0).unwrap();
-    let json_with_version =
-        make_me_sad(&input_str, HashFunctionCode::Blake3_256, protocol_version, None).unwrap();
+    let json_with_version = make_me_sad(
+        &input_str,
+        HashFunctionCode::Blake3_256,
+        protocol_version,
+        None,
+    )
+    .unwrap();
     assert_eq!(
         json_with_version,
         r#"{"v":"DKMS00JSON000067_","hi":"there","d":"EEjVw3gkdhqfHoLypHgpKtxWvK9II8B91g6EAP5Scdtb","blah":"blah"}"#


### PR DESCRIPTION
- add custom filed for SAD (not sure if this should be like that as SAD spec defines that it has to be `d` ) - to consider moving to separate function - we need it for calculating oca-bundles where we have `digest` as filed
- add make_me_happy to calculate any object without `ProtocolVersion` we need it for calculating `overlays` and `capture_base` which does not have version. 